### PR TITLE
Add maintainer field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,7 @@
 name=Nokia5110
 version=0.1
 author=Nitin Sharma <nitin.email@yahoo.com>
+maintainer=Nitin Sharma <nitin.email@yahoo.com>
 sentence=Nokia 5110 lcd library for Arduino
 paragraph=Supports printing strings on the LCD
 category=Display


### PR DESCRIPTION
The Arduino IDE considers the library invalid when the library.properties file is missing the maintainer field:
```
Invalid library found in E:\Stuff\misc\electronics\arduino\libraries\Nokia5110LCD-master: Missing 'maintainer' from library
```