### PR TITLE
Implement keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,8 @@
-arduino
-lcd
-nokia 5110
-library
-display
+Nokia5110	KEYWORD1
+
+initLCD	KEYWORD2
+LcdXY	KEYWORD2
+LcdWriteString	KEYWORD2
+clearLCD	KEYWORD2
+
+ASCII	LITERAL1


### PR DESCRIPTION
keywords.txt is used to define the library's keywords for special highlighting by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords